### PR TITLE
fixing cre.sh oversight

### DIFF
--- a/cre.sh
+++ b/cre.sh
@@ -296,7 +296,7 @@ then
 fi
 
 #if cleanup set, also make the synonymous report
-if [ $cleanup -eq 1 ]
+if [ $cleanup -eq 1 && "$type" == "wes.regular" ]
 then
     type="wes.synonymous"
     f_make_report


### PR DESCRIPTION
prevent synonymous reports from being run when wgs type specified