### PR TITLE
Validate fix

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -11,6 +11,7 @@ We will make updates to cre every six months, and we will perform validation at 
 2. `qsub -F ~/cre/validation/compare_reports.pbs "<first_csv> <second_csv> <first_db> <second_db>"`
    
    where <first_db> refers to the gemini database associated with the first report, and <second_db> refers to the gemini database associated with the second report. 
+   To retrieve the updated/newly added column names from the db for comparison, you must manually add these column names as last arguments in the lines calling "gemini_compare.sh" inside the `compare_reports.pbs`
    
    Outputs:
     *  summary.txt: summarizes the number of variants shared between reports, and variants unique to each report. Also lists the column headers that differ between reports.
@@ -68,10 +69,9 @@ Validate pipeline performance using GIAB benchmark datasets.
    qsub rtg-validations.pbs -v truth="<path to truth vcf>",test="<path to test vcf>",out="output folder name"[,bed="<path to high-conf bed>",restrict="<path to exomes.bed>"(optional)]
    ```
 
-
 4. The truth set calls are from Whole-genome, and so there will be higher number of false negatives when benchmarking WES calls. You can do one of the below steps to restrict regions to exomes,
-   1. intersect the giab high-confidence bed and "exome.bed" with bedtools and pass this as `bed=intersect.bed` to the script (see [here](https://github.com/bcbio/bcbio-nextgen/blob/747045809e493a5cca0dad0ec4ff053afafd6708/config/examples/NA12878.validate.sh) what to use for exome.bed)
-   2. pass `bed=giab-high-conf.bed,restrict=exome.bed` to the script (this may have some effect in scoring as per this [thread](https://groups.google.com/a/realtimegenomics.com/g/rtg-users/c/eY5ptObCQTo))
+   1. intersect the giab high-confidence bed file with capture kit regions, and callable BED file from bcbio run. Pass this resulting file as `bed`
+   to the script (see [here](https://github.com/bcbio/bcbio-nextgen/blob/747045809e493a5cca0dad0ec4ff053afafd6708/config/examples/NA12878.validate.sh))
 
 ### Outputs
 
@@ -80,12 +80,12 @@ Validate pipeline performance using GIAB benchmark datasets.
 * fp.vcf.gz: false-positive variants
 * tp.vcf.gz: true-positive variants in test set
 * tp-baseline.vcf.gz: true-positive variants in truth set
-* crg2_gatk4.0.12_giab_roc.png: roc created from weigthed_roc.tsv.gz
-* crg2_gatk4.0.12_giab_pr.png: precision-recall curve created from weigthed_roc.tsv.gz
-* crg2_gatk4.0.12_giab_snv-indel_pr.png: precision-recall curve created for snp/indel split using non_snp_roc.tsv.gz and snp_roc.tsv.gz
-* crg2_gatk4.0.12_giab_snv-indel_roc.png: roc created for snp/indel split using non_snp_roc.tsv.gz and snp_roc.tsv.gz
+* <prefix>_roc.png: roc created from weigthed_roc.tsv.gz
+* <prefix>_pr.png: precision-recall curve created from weigthed_roc.tsv.gz
+* <prefix>_snv-indel_pr.png: precision-recall curve created for snp/indel split using non_snp_roc.tsv.gz and snp_roc.tsv.gz
+* <prefix>_snv-indel_roc.png: roc created for snp/indel split using non_snp_roc.tsv.gz and snp_roc.tsv.gz
   
-You can also create a combined ROC/Precision-recall curve using any number of validation results like below,
+You can also create a combined ROC/Precision-recall curve in single plot using any number of validation results like below,
 
 ```bash
 rtg rocplot validation1/weigthed_roc.tsv.gz validation2/weigthed_roc.tsv.gz --png=validation12_roc.png

--- a/validation/compare_reports.pbs
+++ b/validation/compare_reports.pbs
@@ -2,7 +2,8 @@
 
 #PBS -N report_comparison
 #PBS -d .
-#PBS -l vmem=20g,mem=20g
+#PBS -l vmem=30g,mem=30g
+#PBS -l walltime=15:00:00
 #PBS -j oe
 
 
@@ -22,7 +23,7 @@ if [ "${report_type}" != "$(basename $2 .csv | cut -d "." -f2)" ]; then
 	exit;
 fi;
 
-#summarize variant counts and compare annotations
+#summarize variant counts and compare report annotations
 python ~/cre/validation/compare_reports.py -old $1 -new $2
 
 left="${prefix1}.uniq.pos";
@@ -30,9 +31,12 @@ right="${prefix2}.uniq.pos";
 #common="${prefix1}.${prefix2}.common.pos";
 
 #extract db entries
-sh ~/cre/validation/gemini_compare.sh $3 ${prefix1} $4 ${prefix2} $left gene impact ensembl_gene_id callers > ${prefix1}.uniq.db.txt
-sh ~/cre/validation/gemini_compare.sh $3 ${prefix1} $4 ${prefix2} $right gene impact ensembl_gene_id callers > ${prefix2}.uniq.db.txt
-#sh ~/cre/validation/gemini_compare.sh $3 $4 $common gene impact ensembl_gene_id callers > ${prefix1}.${prefix2}.common.db.txt
+script=/hpf/largeprojects/ccmbio/ccmmarvin_shared/validation/scripts;
+sh ${script}/gemini_compare.sh $3 ${prefix1} $4 ${prefix2} $left gene impact ensembl_gene_id callers clinvar_status > ${prefix1}.uniq.db.txt&
+sh ${script}/gemini_compare.sh $3 ${prefix1} $4 ${prefix2} $right gene impact ensembl_gene_id callers clinvar_status > ${prefix2}.uniq.db.txt
+##sh ~/cre/validation/gemini_compare.sh $3 $4 $common gene impact ensembl_gene_id callers > ${prefix1}.${prefix2}.common.db.txt
 
+wait
 
-
+#evaluate differences
+python ~/cre/validation/validation_2020-11.py -db_output1 ${prefix1}.uniq.db.txt -prefix1 ${prefix1} -db_output2 ${prefix2}.uniq.db.txt -prefix2 ${prefix2}


### PR DESCRIPTION
1. `gemini_compare.sh` 
* accepts column names found only in one db. Output `<prefix>.uniq.db.txt` will have "0"  where the db does not have that column
2. `compare_reports.pbs`
* run one of the gemini query command with "&" (slight speed up)
* added calls to `validation_2020-11.py`
3. `README.md`
*  notes on bed file intersection for exome comparisons
*  notes on passing column names inside `compare_reports.pbs`

