### PR TITLE
report-compare

### DIFF
--- a/validation/validation_2020-11.py
+++ b/validation/validation_2020-11.py
@@ -36,7 +36,7 @@ def get_explanations(report1_var, report2_var):
                 explanation[variant] = 'Variant not present in comparison database'
         # if only one caller and not GATK:
         elif report2_var[variant]['callers'] == 'freebayes' or report2_var[variant]['callers'] == 'samtools' or report2_var[variant]['callers'] == 'platypus':
-            explanation[variant] = 'Variant only called by one of freebayes, samtools, or platypus in new report'
+            explanation[variant] = 'Variant only called by one of freebayes, samtools, or platypus in other report'
         # change in clinvar annotation
         elif report1_var[variant]['clinvar_sig'] != 'None' and report2_var[variant]['clinvar_sig'] == 'None':
             explanation[variant] = 'Change in clinvar_sig from %s to None'%report1_var[variant]['clinvar_sig']
@@ -49,15 +49,15 @@ def get_explanations(report1_var, report2_var):
         #min(depth) >= 10 (why variants were not included previously)
         #max(alt_depth)>= 3 (why variants are included)
         elif report1_var[variant]['depths'] >= 10 and min(report2_var[variant]['depths']) < 10:
-            explanation[variant] = 'Max depth less than 10'
+            explanation[variant] = 'Max depth greater than 10 in new report and less than 10 in other report'
         elif report1_var[variant]['alt_depths'] >= 3 and max(report2_var[variant]['alt_depths']) < 3 :
-            explanation[variant] = 'Alt depth less than 3'
+            explanation[variant] = 'Alt depth less than 3 in other report'
         #some old reports were filtered by depth < 10
         elif report1_var[variant]['alt_depths'] >= 3 and max(report2_var[variant]['depths']) < 10 :
-            explanation[variant] = 'Max depth less than 10 but alt depth >3'
+            explanation[variant] = 'Max depth less than 10 in both reports but alt depth >3 in this report'
         #were very old reports not filtered by depth?
         elif report1_var[variant]['alt_depths'] < 3 and max(report2_var[variant]['alt_depths']) < 3 :
-            explanation[variant] = 'Alt depth less than 3'
+            explanation[variant] = 'Alt depth less than 3 in both'
         #elif 'clinvar_status' in report1_var[variant]:
         elif not report1_var[variant]['clinvar_status'] in ['None',"0"] and report2_var[variant]['clinvar_status'] == "0":
             explanation[variant] = 'clinvar_status: %s'%(report1_var[variant]['clinvar_status'])

--- a/validation/validation_2020-11.py
+++ b/validation/validation_2020-11.py
@@ -46,17 +46,13 @@ def get_explanations(report1_var, report2_var):
         elif report1_var[variant]['impact_severity'] != 'LOW' and report2_var[variant]['impact_severity'] == 'LOW':
             explanation[variant] = 'Change in impact_severity from %s to LOW'%report1_var[variant]['impact_severity']
 
-        #min(depth) >= 10 (why variants were not included previously)
         #max(alt_depth)>= 3 (why variants are included)
-        elif report1_var[variant]['depths'] >= 10 and min(report2_var[variant]['depths']) < 10:
-            explanation[variant] = 'Max depth greater than 10 in new report and less than 10 in other report'
         elif report1_var[variant]['alt_depths'] >= 3 and max(report2_var[variant]['alt_depths']) < 3 :
             explanation[variant] = 'Alt depth less than 3 in other report'
-        #some old reports were filtered by depth < 10
-        elif report1_var[variant]['alt_depths'] >= 3 and max(report2_var[variant]['depths']) < 10 :
-            explanation[variant] = 'Max depth less than 10 in both reports but alt depth >3 in this report'
+        elif report1_var[variant]['alt_depths'] == -1 and max(report2_var[variant]['alt_depths']) < 3 :
+            explanation[variant] = 'Alt depth less than 3 in other report'
         #were very old reports not filtered by depth?
-        elif report1_var[variant]['alt_depths'] < 3 and max(report2_var[variant]['alt_depths']) < 3 :
+        elif 0 < report1_var[variant]['alt_depths'] < 3 and max(report2_var[variant]['alt_depths']) < 3 :
             explanation[variant] = 'Alt depth less than 3 in both'
         #elif 'clinvar_status' in report1_var[variant]:
         elif not report1_var[variant]['clinvar_status'] in ['None',"0"] and report2_var[variant]['clinvar_status'] == "0":
@@ -65,6 +61,9 @@ def get_explanations(report1_var, report2_var):
         #impact or callers affect inclusion/exclusion
         elif (report1_var[variant]['alt_depths'] == -1 or max(report2_var[variant]['alt_depths']) == -1 ) and ( not "gatk" in report1_var[variant]['callers']):
             explanation[variant] = 'Alt depths -1 and called by non-GATK callers'
+        #very old report may have depth > 10 filter
+        elif report1_var[variant]['alt_depths'] >= 3 and max(report2_var[variant]['depths']) < 10 :
+             explanation[variant] = 'Max depth less than 10 in both reports but alt depth >3 in this report'
         else:
             explanation[variant] = 'Cannot explain'
     return explanation

--- a/validation/validation_2020-11.py
+++ b/validation/validation_2020-11.py
@@ -34,10 +34,15 @@ def get_explanations(report1_var, report2_var):
                 explanation[variant] = 'Variant only called by GATK'
             else:   
                 explanation[variant] = 'Variant not present in comparison database'
+        # if only one caller and not GATK:
+        elif report2_var[variant]['callers'] == 'freebayes' or report2_var[variant]['callers'] == 'samtools' or report2_var[variant]['callers'] == 'platypus':
+            explanation[variant] = 'Variant only called by one of freebayes, samtools, or platypus in new report'
+        # change in clinvar annotation
         elif report1_var[variant]['clinvar_sig'] != 'None' and report2_var[variant]['clinvar_sig'] == 'None':
             explanation[variant] = 'Change in clinvar_sig from %s to None'%report1_var[variant]['clinvar_sig']
         elif report1_var[variant]['clinvar_pathogenic'] != 'None' and report2_var[variant]['clinvar_pathogenic'] == 'None':
             explanation[variant] = 'Change in clinvar_pathogenic from %s to None'%report1_var[variant]['clinvar_pathogenic']
+        # change in impact severity (vep)
         elif report1_var[variant]['impact_severity'] != 'LOW' and report2_var[variant]['impact_severity'] == 'LOW':
             explanation[variant] = 'Change in impact_severity from %s to LOW'%report1_var[variant]['impact_severity']
 
@@ -77,7 +82,8 @@ if __name__ == "__main__":
     today = date.today()
     today = today.strftime("%Y-%m-%d")
     explanation_1_df = pd.DataFrame.from_dict(explanation_1, orient='index').reset_index()
-    explanation_1_df.to_csv('validation_summary_unique_in_%s_%s.csv'%(args.prefix1,today), header=['Variant', 'Explanation'], index=False)
+    if len(explanation_1_df) != 0:
+        explanation_1_df.to_csv('validation_summary_unique_in_%s_%s.csv'%(args.prefix1,today), header=['Variant', 'Explanation'], index=False)
 
     # For variants unique to report 2, determine reason they were not included in report 1
     db2_unique = db_output_to_dict(args.db_output2)
@@ -86,4 +92,5 @@ if __name__ == "__main__":
     explanation_2 = get_explanations(report2_var, report1_var)
     
     explanation_2_df = pd.DataFrame.from_dict(explanation_2, orient='index').reset_index()
-    explanation_2_df.to_csv('validation_summary_unique_in_%s_%s.csv'%(args.prefix2,today), header=['Variant', 'Explanation'], index=False)
+    if len(explanation_2_df) != 0:
+        explanation_2_df.to_csv('validation_summary_unique_in_%s_%s.csv'%(args.prefix2,today), header=['Variant', 'Explanation'], index=False)


### PR DESCRIPTION
use this to branch add/edit conditions to explain variants in "Cannot explain" category. 
newly added:
1. `min(depth) < 10`: explains variants previously excluded
2. `max(alt_depth) >= 3`: explains variants included in new reports
3. `clinvar_status != None`: explains variants newly added based on the Hillary `helrick/clinvar_updates` branch
4. `"-1" in alt_depth and "gatk" not in caller`: most of the "cannot explain" were called by freebayes/platypus and hence  missing AD/DP. Not very confident this is even a criteria anywhere, but keeping it for now.
