### PR TITLE
create genome-wide de novo report

### DIFF
--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -95,7 +95,7 @@ then
     s_gt_filter="((gt_types."$proband" == HET or gt_types."$proband" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
 	and (gt_alt_depths."$proband" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
     and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
-    sQuery=$sQuery " and qual>=400"
+    sQuery=$sQuery" and qual>=400"
     gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
 else
     s_gt_filter="(gt_alt_depths).(*).(>="${alt_depth}").(any) or (gt_alt_depths).(*).(==-1).(all)"

--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -89,11 +89,10 @@ s_gt_filter=''
 if [ -n "$denovo" ] && [ "$denovo" == 1 ]
 then
     proband=`gemini query -q "select name from samples where phenotype=2" $file`
-    mom=`gemini query -q "select name from samples where phenotype=1 and sex=2" $file`
-    dad=`gemini query -q "select name from samples where phenotype=1 and sex=1" $file`
+    mom=`gemini query -q "select name from samples where phenotype=-9 and sex=2" $file`
+    dad=`gemini query -q "select name from samples where phenotype=-9 and sex=1" $file`
     
-    s_gt_filter="gt_types."$proband" == 1 and (gt_types."$dad" == 0 or gt_types."$dad" == 3) and (gt_types."$mom" == 0 or gt_types."$mom" == 3)"
-#		 (gt_types."$proband" == )"
+    s_gt_filter="(gt_types."$proband" == HET and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF)  and ((gt_alt_depths).(*).(>="${alt_depth}").(any) or (gt_alt_depths).(*).(==-1).(all))"
     sQuery=$sQuery" and qual>=500"
     gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
 else

--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -92,8 +92,10 @@ then
     mom=`gemini query -q "select name from samples where phenotype=-9 and sex=2" $file`
     dad=`gemini query -q "select name from samples where phenotype=-9 and sex=1" $file`
     
-    s_gt_filter="(gt_types."$proband" == HET and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF)  and ((gt_alt_depths).(*).(>="${alt_depth}").(any) or (gt_alt_depths).(*).(==-1).(all))"
-    sQuery=$sQuery" and qual>=500"
+    s_gt_filter="((gt_types."$proband" == HET or gt_types."$proband" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
+	and (gt_alt_depths."$proband" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
+    and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
+    sQuery=$sQuery " and qual>=400"
     gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
 else
     s_gt_filter="(gt_alt_depths).(*).(>="${alt_depth}").(any) or (gt_alt_depths).(*).(==-1).(all)"

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -113,13 +113,16 @@ if [ -n "$denovo" ] && [ "$denovo" == 1 ]
 then
     # https://www.biostars.org/p/359117/
     proband=`gemini query -q "select name from samples where phenotype=2" $file`
-    mom=`gemini query -q "select name from samples where phenotype=1 and sex=2" $file`
-    dad=`gemini query -q "select name from samples where phenotype=1 and sex=1" $file`
+    mom=`gemini query -q "select name from samples where phenotype=-9 and sex=2" $file`
+    dad=`gemini query -q "select name from samples where phenotype=-9 and sex=1" $file`
     
-    s_gt_filter="gt_types."$proband" == HET and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF"
+    s_gt_filter="(gt_types."$proband" == HET and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
+    and (gt_alt_depths."$proband" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
+    and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
+    echo $s_gt_filter
     #(gt_types."$proband" == HOM_ALT and gt_types."$dad" == HOM_REF and gt_types."$mom" == HET)"
     # otherwise a lot of trash variants
-    sQuery=$sQuery" and qual>=500"
+    sQuery=$sQuery" and qual>=400"
     gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
 else
     # keep variant where the alt depth is >=3 in any one of the samples or they're all -1 (sometimes happens for freebayes called variants?)

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -116,7 +116,7 @@ then
     mom=`gemini query -q "select name from samples where phenotype=-9 and sex=2" $file`
     dad=`gemini query -q "select name from samples where phenotype=-9 and sex=1" $file`
     
-    s_gt_filter="(gt_types."$proband" == HET and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
+    s_gt_filter="((gt_types."$proband" == HET or gt_types."$proband" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
     and (gt_alt_depths."$proband" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
     and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
     echo $s_gt_filter

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -122,7 +122,7 @@ then
     echo $s_gt_filter
     #(gt_types."$proband" == HOM_ALT and gt_types."$dad" == HOM_REF and gt_types."$mom" == HET)"
     # otherwise a lot of trash variants
-    sQuery=$sQuery" and qual>=400"
+    sQuery=$sQuery" and qual>=400 and Old_multiallelic is null"
     gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
 else
     # keep variant where the alt depth is >=3 in any one of the samples or they're all -1 (sometimes happens for freebayes called variants?)

--- a/cre.sh
+++ b/cre.sh
@@ -19,7 +19,6 @@
 
 # default settings:
 # max af > 0.1, ad > 3, plus and any variants with a clinvar entry and ad > 1
-
 # cleanup is different for wes.fast template - don't remove gatk db
 function f_cleanup
 {
@@ -161,6 +160,12 @@ function f_make_report
     awk '!a[$0]++' $family.variants.all.txt > $family.variants.txt
     awk '!a[$0]++' $family.variant_impacts.all.txt > $family.variant_impacts.txt
 
+    if [ "$type" == "denovo" ]
+    then
+			#gemini prints the genotype filter to the first line of the file, need to remove
+            tail -n +2 $family.variants.txt > $family.variants.trim.txt
+            mv $family.variants.trim.txt $family.variants.txt
+    fi 
 
     # report filtered vcf for import in phenotips
     # note that if there is a multiallelic SNP, with one rare allele and one frequent one, both will be reported in the VCF,

--- a/cre.sh
+++ b/cre.sh
@@ -10,6 +10,7 @@
 # 	type = [ wes.regular (default) | wes.synonymous | wes.fast | rnaseq | wgs | annotate (only for cleaning) | 
 # 	    denovo (all rare variants in wgs, proband should have phenotype=2, parents=phenotype1 also sex for parents in gemini.db) ]
 #	max_af = af filter, default = 0.01
+#   ped = pedigree file, used to amend gemini db with sample information to generate de novo report
 ####################################################################################################
 
 #PBS -l walltime=23:00:00,nodes=1:ppn=1
@@ -150,7 +151,12 @@ function f_make_report
     
     if [ "$type" == "denovo" ]
     then
-			export denovo=1
+        export denovo=1
+        if [ ! -z "$ped" ]
+        then
+            echo "Amending gemini db with pedigree information"
+            gemini amend --sample $ped ${family}-ensemble.db 
+        fi
     fi
 
     ~/cre/cre.gemini2txt.vcf2db.sh ${family}-ensemble.db $depth_threshold $severity_filter $max_af > $family.variants.all.txt
@@ -162,9 +168,9 @@ function f_make_report
 
     if [ "$type" == "denovo" ]
     then
-			#gemini prints the genotype filter to the first line of the file, need to remove
-            tail -n +2 $family.variants.txt > $family.variants.trim.txt
-            mv $family.variants.trim.txt $family.variants.txt
+		#gemini prints the genotype filter to the first line of the file, need to remove
+        tail -n +2 $family.variants.txt > $family.variants.trim.txt
+        mv $family.variants.trim.txt $family.variants.txt
     fi 
 
     # report filtered vcf for import in phenotips

--- a/cre.vcf2cre.sh
+++ b/cre.vcf2cre.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#PBS -l walltime=100:00:00,nodes=1:ppn=5
+#PBS -l walltime=100:00:00,nodes=1:ppn=14
 #PBS -joe .
 #PBS -d .
-#PBS -l vmem=50g,mem=50g
+#PBS -l vmem=70g,mem=70g
 
 # 50g is crucial -20,30 crashes sometimes
 

--- a/generate_reports.sh
+++ b/generate_reports.sh
@@ -5,19 +5,15 @@
 
 family=$1
 report_type=$2
+ped=$3
 curr_date=$(date +"%Y-%m-%d")
 
 rerun_folder="${family}_${curr_date}"
 
-if [ "$3" == "-email" ]; then
-  email_flag="-m e"
-else
-	email_flag=""
-fi
 
 if [ "$report_type" == "wes" ] || [ "$report_type" == "wes.both" ]; then
 	eval script="~/cre/cre.vcf2cre.sh"
-elif [ "$report_type" == "wgs" ]; then
+elif [ "$report_type" == "wgs" ] || [ "$report_type" == "denovo" ]; then
 	eval script="~/crg/crg.vcf2cre.sh"
 else
 	echo "Please enter a report type (wes, wes.both, or wgs)"
@@ -40,7 +36,7 @@ if [ -f $family_vcf ]; then
 	cp ../${family_vcf} .
 	# for exome reports, need variant tables from the four variant callers
 	cp ../*table . 
-	vcf2cre_job="$(qsub "${script}" -v original_vcf="${family_vcf}",project=${family})"
+	vcf2cre_job="$(qsub "${script}" -v original_vcf="${family_vcf}",project=${family},ped=${ped})"
 else
 	echo "${family_vcf} not present, exiting."
 	cd ../..
@@ -57,6 +53,9 @@ elif [ "$report_type" = "wes" ]; then
 	echo "Regular WES Report Job ID: ${report_job}"
 elif [ "$report_type" = "wgs" ]; then
 	report_job="$(qsub ~/cre/cre.sh -W depend=afterany:"${vcf2cre_job}" -v family=${family},type=wgs)"
+  echo "WGS Report Job ID: ${report_job}"
+elif [ "$report_type" = "denovo" ]; then
+	report_job="$(qsub ~/cre/cre.sh -W depend=afterany:"${vcf2cre_job}" -v family=${family},type=denovo)"
   echo "WGS Report Job ID: ${report_job}"
 fi
 


### PR DESCRIPTION
This functionality can only be used if a .ped file is available for a trio. The information in the .ped file (i.e. parental information, affected status) is incorporated into the gemini db after the vcf is annotated. 

To generate the de novo report:

`generate_reports.sh <family> denovo <path to ped file>`