### PR TITLE
fix variant impact bug

### DIFF
--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -102,7 +102,7 @@ else
     # grab the clinvar variants
     cQuery=$initialQuery 
     # everything that has a clinvar_sig value
-	cQuery=$cQuery" where v.gnomad_af_popmax <= ${max_af} and v.variant_id=i.variant_id and clinvar_sig <> '' "$caller_filter" "
+	cQuery=$cQuery" where v.gnomad_af_popmax <= ${max_af} and v.variant_id=i.variant_id and v.clinvar_status <> '' "$caller_filter" "
     #cQuery=$cQuery" where gnomad_af_popmax <= ${max_af} and v.variant_id=i.variant_id and clinvar_sig <> ''"
     # only get variants where AD >= 1 (any sample with an alternate read)
     s_gt_filter="(gt_alt_depths).(*).(>=1).(any) or (gt_alt_depths).(*).(==-1).(all)"


### PR DESCRIPTION
The variant impact for variants with gnomad_af_popmax < 1% and LOW impact (e.g. synonymous, intronic) and non-empty clinvar_status was improperly queried, resulting in the 'Info' field for these variants being blank. This commit fixes that bug.