### PR TITLE
Updating to gnomAD 2.1.1 in Annotation Config Files

### DIFF
--- a/config/cre.bcbio.templates.wes.yaml
+++ b/config/cre.bcbio.templates.wes.yaml
@@ -24,7 +24,7 @@ details:
     - platypus
     - freebayes
     vcfanno:
-    - /home/ccmmarvin/cre/cre.vcfanno.conf
+    - /home/nhanafi/cre/cre.vcfanno.conf
   analysis: variant2
   description: '912R_A337376'
   files:

--- a/cre.vcfanno.conf
+++ b/cre.vcfanno.conf
@@ -1,12 +1,12 @@
 [[annotation]]
-file="variation/gnomad_exome.vcf.gz"
-fields=["AC","Hom","AF_POPMAX","AN"]
+file="variation/gnomad_exome.2.1.1.vcf.gz"
+fields=["AC","nhomalt_popmax","AF_popmax","AN"]
 names=["gnomad_ac_es","gnomad_hom_es","gnomad_af_es","gnomad_an_es"]
 ops=["first","first","first","first"]
 
 [[annotation]]
-file="variation/gnomad_genome.normalized.vcf.gz"
-fields=["AC", "Hom","AF_POPMAX","AN"]
+file="variation/gnomad_genome.2.1.1.vcf.gz"
+fields=["AC", "nhomalt_popmax","AF_popmax","AN"]
 names=["gnomad_ac_gs", "gnomad_hom_gs","gnomad_af_gs","gnomad_an_gs"]
 ops=["self","self","self","self"]
 


### PR DESCRIPTION
Config file now points to new gnomAD exome and genome VCFs, and the config fields have been modified to reflect the updated VCF fields ('AF_popmax' instead of 'AF_POPMAX', and 'nhomalt_popmax' instead of 'Hom').
