### PR TITLE
Fixed mem issue for the validation RTG vcfeval script

### DIFF
--- a/validation/rtg-validations.pbs
+++ b/validation/rtg-validations.pbs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #PBS -N rtg-snv
-#PBS -l vmem=500g,mem=500g
+#PBS -l vmem=40g,mem=40g
 #PBS -l walltime=15:00:00
 #PBS -l nodes=1:ppn=1
 #PBS -j oe
@@ -30,7 +30,7 @@ if [ ! -z $restrict ]; then
 	extra=${extra}" --bed-regions=$restrict"
 fi;
 
-export _JAVA_OPTIONS="-Xmx80g"
+export _JAVA_OPTIONS="-Xmx30g"
 RTG=/hpf/largeprojects/ccmbio/arun/Tools/rtg-tools/rtg-tools-3.10.1/RTG.jar;
 SDF=/hpf/largeprojects/ccmbio/ccmmarvin_shared/validation/benchmarking/GRch37_SDF;
 


### PR DESCRIPTION
500g of requested memory was sending this job to the bigmem queue unnecessarily: changed these requirements to 40g and Xmx=30g so that it can be picked up and run faster.