### PR TITLE
Adding genome-wide CADD scores.

### DIFF
--- a/cre.vcfanno.conf
+++ b/cre.vcfanno.conf
@@ -58,12 +58,26 @@ fields=["CLNSIG","CLNREVSTAT"]
 names=["clinvar_pathogenic", "clinvar_status"]
 ops=["concat", "concat"]
     
+#CADD 1.6 - SNVs
+[[annotation]]
+file = "variation/CADD-1.6_whole_genome_SNVs.tsv.gz"
+names = ["CADD_phred"]
+columns = [6]
+ops = ["self"]
+
+#CADD 1.6 - indels
+[[annotation]]
+file = "variation/CADD-1.6_InDels.tsv.gz"
+names = ["CADD_phred"]
+columns = [6]
+ops = ["self"]
+
 #dbNSFP v3.4
 [[annotation]]
 file = "variation/dbNSFP.txt.gz"
-names = ["CADD_phred","phyloP20way_mammalian","phastCons20way_mammalian","Vest3_score","Revel_score","Gerp_score"]
-columns = [79,111,115,58,70,107]
-ops = ["first","first","first","first","first","first"]
+names = ["phyloP20way_mammalian","phastCons20way_mammalian","Vest3_score","Revel_score","Gerp_score"]
+columns = [111,115,58,70,107]
+ops = ["first","first","first","first","first"]
 
 # spliceAI
 [[annotation]]


### PR DESCRIPTION
- Removed current CADD annotation from the dbNSFP block in the vcfanno config.
- Added in new CADD annotation blocks to the vcfanno config from the full genome SNV and indel tsv files. 