### PR TITLE
added line to parse multiple platypus AD values

### DIFF
--- a/validation/validation_2021-10.py
+++ b/validation/validation_2021-10.py
@@ -88,6 +88,8 @@ def get_explanations(report1_var, report2_var, report2_dir):
     # platypus  alt depth cols
     if platypus is not None:
         platypus_ad_cols = get_platypus_nv_cols(platypus.columns)
+        for col in platypus_ad_cols:
+            platypus[col] = platypus.apply(lambda row: parse_ad(row[col]), axis=1)
         platypus["AD_max"] = platypus.apply(
             lambda row: get_max_ad([row[col] for col in platypus_ad_cols]), axis=1
         )


### PR DESCRIPTION
This is to fix an issue that arose when comparing synonymous reports - some variants in the platypus table file have 2 comma-separated values in the AD column which threw an error with the validation_2021-10.py script. I enabled the parse_ad functionality for the platypus file to solve this issue. 