### PR TITLE
Create denovo report with variants from multiple probands

### DIFF
--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -88,7 +88,7 @@ s_gt_filter=''
 
 if [ -n "$denovo" ] && [ "$denovo" == 1 ]
 then
-    proband=`gemini query -q "select name from samples where paternal_id != -9 and maternal_id != -9" $file`
+    proband=`gemini query -q "select name from samples where paternal_id != -9 and paternal_id != 0 and maternal_id != -9 and maternal_id != 0" $file`
 
 	# print header
     header=$sQuery" limit 0"

--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -88,15 +88,23 @@ s_gt_filter=''
 
 if [ -n "$denovo" ] && [ "$denovo" == 1 ]
 then
-    proband=`gemini query -q "select name from samples where phenotype=2" $file`
-    mom=`gemini query -q "select name from samples where phenotype=-9 and sex=2" $file`
-    dad=`gemini query -q "select name from samples where phenotype=-9 and sex=1" $file`
+    proband=`gemini query -q "select name from samples where paternal_id != -9 and maternal_id != -9" $file`
+
+	# print header
+    header=$sQuery" limit 0"
+    gemini query -q "$header" --header $file
     
-    s_gt_filter="((gt_types."$proband" == HET or gt_types."$proband" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
-	and (gt_alt_depths."$proband" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
-    and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
-    sQuery=$sQuery" and qual>=400"
-    gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
+	# get de novo variants for each affected proband
+    for p in $proband
+	do
+		mom=`gemini query -q "select maternal_id from samples where name == '$p'" $file`
+        dad=`gemini query -q "select paternal_id from samples where name == '$p'" $file`
+		s_gt_filter="((gt_types."$p" == HET or gt_types."$p" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
+		and (gt_alt_depths."$p" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
+		and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
+		sQuery=$sQuery" and qual>=400"
+		gemini query -q "$sQuery" --gt-filter "$s_gt_filter" $file
+	done
 else
     s_gt_filter="(gt_alt_depths).(*).(>="${alt_depth}").(any) or (gt_alt_depths).(*).(==-1).(all)"
 	gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -129,18 +129,24 @@ s_gt_filter=''
 if [ -n "$denovo" ] && [ "$denovo" == 1 ]
 then
     # https://www.biostars.org/p/359117/
-    proband=`gemini query -q "select name from samples where phenotype=2" $file`
-    mom=`gemini query -q "select name from samples where phenotype=-9 and sex=2" $file`
-    dad=`gemini query -q "select name from samples where phenotype=-9 and sex=1" $file`
-    
-    s_gt_filter="((gt_types."$proband" == HET or gt_types."$proband" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
-    and (gt_alt_depths."$proband" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
-    and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
-    echo $s_gt_filter
-    #(gt_types."$proband" == HOM_ALT and gt_types."$dad" == HOM_REF and gt_types."$mom" == HET)"
-    # otherwise a lot of trash variants
-    sQuery=$sQuery" and qual>=400 and Old_multiallelic is null"
-    gemini query -q "$sQuery" --gt-filter "$s_gt_filter" --header $file
+    proband=`gemini query -q "select name from samples where paternal_id != -9 and maternal_id != -9" $file`
+
+    # print header
+    header=$sQuery" limit 0"
+    gemini query -q "$header" --header $file
+
+    # get de novo variants for each affected proband
+    for p in $proband
+    do
+        mom=`gemini query -q "select maternal_id from samples where name == '$p'" $file`
+        dad=`gemini query -q "select paternal_id from samples where name == '$p'" $file`
+        s_gt_filter="((gt_types."$p" == HET or gt_types."$p" == HOM_ALT) and gt_types."$dad" == HOM_REF and gt_types."$mom" == HOM_REF) \
+        and (gt_alt_depths."$p" >="${alt_depth}" or (gt_alt_depths).(*).(==-1).(all)) \
+        and ((gt_alt_depths."$dad" < 10 and gt_alt_depths."$mom" < 10)  or (gt_alt_depths).(*).(==-1).(all))"
+        # otherwise a lot of trash variants
+        sQuery=$sQuery" and qual>=400 and Old_multiallelic is null"
+        gemini query -q "$sQuery" --gt-filter "$s_gt_filter" $file
+    done
 else
     # keep variant where the alt depth is >=3 in any one of the samples or they're all -1 (sometimes happens for freebayes called variants?)
     s_gt_filter="(gt_alt_depths).(*).(>="${alt_depth}").(any) or (gt_alt_depths).(*).(==-1).(all)"

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -129,7 +129,7 @@ s_gt_filter=''
 if [ -n "$denovo" ] && [ "$denovo" == 1 ]
 then
     # https://www.biostars.org/p/359117/
-    proband=`gemini query -q "select name from samples where paternal_id != -9 and maternal_id != -9" $file`
+    proband=`gemini query -q "select name from samples where paternal_id != -9 and paternal_id != 0 and maternal_id != -9 and maternal_id != 0" $file`
 
     # print header
     header=$sQuery" limit 0"

--- a/cre.sh
+++ b/cre.sh
@@ -167,13 +167,6 @@ function f_make_report
     awk '!a[$0]++' $family.variants.all.txt > $family.variants.txt
     awk '!a[$0]++' $family.variant_impacts.all.txt > $family.variant_impacts.txt
 
-    if [ "$type" == "denovo" ]
-    then
-		#gemini prints the genotype filter to the first line of the file, need to remove
-        tail -n +2 $family.variants.txt > $family.variants.trim.txt
-        mv $family.variants.trim.txt $family.variants.txt
-    fi 
-
     # report filtered vcf for import in phenotips
     # note that if there is a multiallelic SNP, with one rare allele and one frequent one, both will be reported in the VCF,
     # and just a rare one in the excel report


### PR DESCRIPTION
The changes here are the following:

- Probands are defined as any individual in a pedigree that has values for maternal_id and paternal_id populated, regardless of affected status
- Parental IDs are derived from the proband's maternal_id and paternal_id fields

This means we can create de novo reports for multi-proband families, e.g. quads; the de novo report will contain putative de novo variants for each proband. A 'proband' here is defined as having both parents present, so de novo variants from unaffected siblings will be included. 