### PR TITLE
Fix hardcoded path to tables

### DIFF
--- a/cre.sh
+++ b/cre.sh
@@ -246,7 +246,7 @@ function f_make_report
     fi
 
     echo GENERATING REPORT WITH TYPE: "${type}"
-    Rscript $cre/cre.vcf2db.R $family "${type}" "${database}"
+    Rscript $cre/cre.vcf2db.R $family "${type}" "${database}" "${cre}/data"
     
     cd $family
     #rm $family.create_report.csv $family.merge_reports.csv

--- a/cre.vcf2db.R
+++ b/cre.vcf2db.R
@@ -864,7 +864,7 @@ library(stringr)
 library(data.table)
 library(plyr)
 library(dplyr)
-default_tables_path <- "~/cre/data"
+
 
 # R substitutes "-" with "." in sample names in columns so fix this in samples.txt
 # sample names starting with letters should be prefixed by X in *.table
@@ -873,6 +873,7 @@ default_tables_path <- "~/cre/data"
 args <- commandArgs(trailingOnly = T)
 print(args)
 family <- args[1]
+default_tables_path <- args[4]
 
 coding <- if(is.null(args[2])) T else F
 coding <- F


### PR DESCRIPTION
cre.vcf2db.R now accepts a variable to specify the `default_tables_path` (path to OMIM, ensemble gene descriptions), instead of defaulting to ~/cre