### PR TITLE
changed default path to database files

### DIFF
--- a/cre.sh
+++ b/cre.sh
@@ -286,7 +286,7 @@ fi
 #default database path
 if [ -z $database ]
 then
-    database="/hpf/largeprojects/ccm_dccforge/dccforge/results/database"
+    database="/hpf/largeprojects/ccmbio/naumenko/tools/bcbio/genomes/Hsapiens/GRCh37/variation"
 fi
 
 #no cleanup by default


### PR DESCRIPTION
This directory was accidentally deleted following the deletion of the dccforge/results cleanup. We have retrieved the C4R exome counts and HGMD databases from the CHEO-RI space, and copied them to the central crg2 annotations directory. Submitting this PR to change the cre database path prefix to that directory. 