### PR TITLE
Dark region annotation for PacBio reports

### DIFF
--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -93,6 +93,7 @@ sQuery="select \
         phylop30way_mammalian as Conserved_in_30_mammals,\
         COALESCE(spliceai_score, '') as SpliceAI_score, \
         uce_100bp as UCE_100bp, uce_200bp as UCE_200bp, \
+        Dark_genes as Dark_genes, \
         $noncoding_anno, \
         gts,"
 

--- a/cre.vcf2db.R
+++ b/cre.vcf2db.R
@@ -409,7 +409,7 @@ create_report <- function(family, samples, type){
     # Column 55: DNaseI_hypersensitive_site  
     # Column 56: CTCF_binding_site
     # Column 57: ENH_cellline_tissue
-        
+
     # replace -1 with 0
     for (field in c("Trio_coverage", "Gnomad_af", "Gnomad_af_popmax")){
         variants[,field] <- with(variants, gsub("-1", "0", get(field), fixed = T))
@@ -449,7 +449,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
                             "Gnomad_oe_lof_score", "Gnomad_oe_mis_score", "Exac_pli_score", "Exac_prec_score", "Exac_pnull_score",
                             "Conserved_in_30_mammals", "SpliceAI_impact", "SpliceAI_score", "Sift_score", "Polyphen_score", "Cadd_score", "Vest4_score", "Revel_score", "Gerp_score",
                             "Imprinting_status", "Imprinting_expressed_allele", "Pseudoautosomal", "Gnomad_male_ac",
-                            "Number_of_callers", "Old_multiallelic", "UCE_100bp", "UCE_200bp"), noncoding_cols)]
+                            "Number_of_callers", "Old_multiallelic", "UCE_100bp", "UCE_200bp", "Dark_genes"), noncoding_cols)]
   
     variants <- variants[order(variants$Position),]
     


### PR DESCRIPTION
- Modified cre.gemini2txt.vcf2db.sh and cre.vcf2db.R to create a new column in the report called "Dark_gene". If a variant falls in the dark region then the column contains the list of genes that fall in that region, else the column value is "None"
- This branch should be used in conjunction with crg2 (crg2-hg38-pacbio-dark-regions) branch