### PR TITLE
Add LinSight_Score to cre repo

### DIFF
--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -50,7 +50,8 @@ then
             enh_cellline_tissue as ENH_cellline_tissue,
             tf_binding_sites as TF_binding_sites,
             c4r_wgs_counts as C4R_WGS_counts,
-            c4r_wgs_samples as C4R_WGS_samples"
+            c4r_wgs_samples as C4R_WGS_samples,
+            LinSight_Score"
 else
     noncoding_anno="00 as noncoding"
 fi

--- a/cre.vcf2db.R
+++ b/cre.vcf2db.R
@@ -429,7 +429,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
 {
     print(colnames(variants))
     if (type == 'wgs' || type == 'denovo'){
-        noncoding_cols <- c("DNaseI_hypersensitive_site", "CTCF_binding_site", "ENH_cellline_tissue", "TF_binding_sites")
+        noncoding_cols <- c("DNaseI_hypersensitive_site", "CTCF_binding_site", "ENH_cellline_tissue", "TF_binding_sites", "LinSight_Score")
         wgs_counts <- c("C4R_WGS_counts", "C4R_WGS_samples")
         variants$C4R_WGS_counts[variants$C4R_WGS_counts == "None"] <- 0 
         variants$C4R_WGS_counts <- as.integer(variants$C4R_WGS_counts)


### PR DESCRIPTION
Following @Madelinehazel shared steps in this message:
"
For the non-coding scores you've incorporated into crg2, you'll need to make some changes to the report generation scripts for hg38 genomes in the [cre](https://github.com/ccmbioinfo/cre/tree/hg38) repo. You will need to checkout the 'hg38' branch. Then, add the name of your annotation (as you specified in vcfanno) [here](https://github.com/ccmbioinfo/cre/blob/master/cre.gemini2txt.vcf2db.sh#L48), as well as in this [script](https://github.com/ccmbioinfo/cre/blob/master/cre.vcf2db.R#L437).
"