### PR TITLE
add ncER, ReMM, and LINSIGHT scores

### DIFF
--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -85,6 +85,9 @@ sQuery="select \
         vest3_score as Vest3_score,\
         revel_score as Revel_score,\
         gerp_score as Gerp_score,\
+        ncER as ncER_score,\
+        ReMM as ReMM_score,\
+        LinSight_Score as LINSIGHT_score,\
         aa_change as AA_change,\
         hgvsc as Codon_change,\
         "$callers" as Callers,\

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -52,8 +52,10 @@ then
             tf_binding_sites as TF_binding_sites,
             c4r_wgs_counts as C4R_WGS_counts,
             c4r_wgs_samples as C4R_WGS_samples"
+    noncoding_scores="ncER as ncER_score, ReMM as ReMM_score, LinSight_Score as LINSIGHT_score"
 else
     noncoding_anno="00 as noncoding"
+    noncoding_scores="00 as noncoding_scores"
 fi
 
 sQuery="select \
@@ -85,9 +87,7 @@ sQuery="select \
         vest3_score as Vest3_score,\
         revel_score as Revel_score,\
         gerp_score as Gerp_score,\
-        ncER as ncER_score,\
-        ReMM as ReMM_score,\
-        LinSight_Score as LINSIGHT_score,\
+        $noncoding_scores, \
         aa_change as AA_change,\
         hgvsc as Codon_change,\
         "$callers" as Callers,\

--- a/cre.vcf2db.R
+++ b/cre.vcf2db.R
@@ -435,6 +435,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
     print(colnames(variants))
     if (type == 'wgs' || type == 'denovo'){
         noncoding_cols <- c("DNaseI_hypersensitive_site", "CTCF_binding_site", "ENH_cellline_tissue", "TF_binding_sites")
+        noncoding_scores <- c("ncER_score", "ReMM_score", "LINSIGHT_score")
         wgs_counts <- c("C4R_WGS_counts", "C4R_WGS_samples")
         variants$C4R_WGS_counts[variants$C4R_WGS_counts == "None"] <- 0 
         variants$C4R_WGS_counts <- as.integer(variants$C4R_WGS_counts)
@@ -442,6 +443,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
         }
     else {
         noncoding_cols <- c()
+        noncoding_scores <- c()
         wgs_counts <- c()
         }
     variants <- variants[c(c("Position", "UCSC_Link", "GNOMAD_Link", "Ref", "Alt"),
@@ -452,14 +454,17 @@ select_and_write2 <- function(variants, samples, prefix, type)
                           paste0("Alt_depths.", samples),
                           c("Trio_coverage", "Ensembl_gene_id", "Gene_description", "omim_phenotype", "omim_inheritance",
                             "Orphanet", "Clinvar",
-                            "C4R_WES_counts", "C4R_WES_samples"), wgs_counts, c("HGMD_id", "HGMD_gene", "HGMD_tag", "HGMD_ref",
+                            "C4R_WES_counts", "C4R_WES_samples"), 
+                          wgs_counts, 
+                          c("HGMD_id", "HGMD_gene", "HGMD_tag", "HGMD_ref",
                             "Gnomad_af_popmax", "Gnomad_af", "Gnomad_ac", "Gnomad_hom",
                             "Ensembl_transcript_id", "AA_position", "Exon", "Protein_domains", "rsIDs",
                             "Gnomad_oe_lof_score", "Gnomad_oe_mis_score", "Exac_pli_score", "Exac_prec_score", "Exac_pnull_score",
-                            "Conserved_in_20_mammals", "SpliceAI_impact", "SpliceAI_score", "Sift_score", "Polyphen_score", "Cadd_score", "Vest3_score", "Revel_score", "Gerp_score",
-                            "ncER_score", "ReMM_score", "LINSIGHT_score",
-                            "Imprinting_status", "Imprinting_expressed_allele", "Pseudoautosomal", "Gnomad_male_ac",
-                            "Number_of_callers", "Old_multiallelic", "UCE_100bp", "UCE_200bp"), noncoding_cols)]
+                            "Conserved_in_20_mammals", "SpliceAI_impact", "SpliceAI_score", "Sift_score", "Polyphen_score", "Cadd_score", "Vest3_score", "Revel_score", "Gerp_score"),
+                           noncoding_scores,
+                           c("Imprinting_status", "Imprinting_expressed_allele", "Pseudoautosomal", "Gnomad_male_ac",
+                            "Number_of_callers", "Old_multiallelic", "UCE_100bp", "UCE_200bp"), 
+                           noncoding_cols)]
   
     variants <- variants[order(variants$Position),]
 

--- a/cre.vcf2db.R
+++ b/cre.vcf2db.R
@@ -457,6 +457,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
                             "Ensembl_transcript_id", "AA_position", "Exon", "Protein_domains", "rsIDs",
                             "Gnomad_oe_lof_score", "Gnomad_oe_mis_score", "Exac_pli_score", "Exac_prec_score", "Exac_pnull_score",
                             "Conserved_in_20_mammals", "SpliceAI_impact", "SpliceAI_score", "Sift_score", "Polyphen_score", "Cadd_score", "Vest3_score", "Revel_score", "Gerp_score",
+                            "ncER_score", "ReMM_score", "LINSIGHT_score",
                             "Imprinting_status", "Imprinting_expressed_allele", "Pseudoautosomal", "Gnomad_male_ac",
                             "Number_of_callers", "Old_multiallelic", "UCE_100bp", "UCE_200bp"), noncoding_cols)]
   


### PR DESCRIPTION
Add non-coding scores (nCER, ReMM, LINSIGHT) to WGS reports (panel, panel-flank, de novo). Scores are not added for exomes or WGS coding reports.