### PR TITLE
Alphamissense annotation for hg38

### DIFF
--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -84,6 +84,7 @@ sQuery="select \
         vest4_score as Vest4_score,\
         revel_score as Revel_score,\
         gerp_score as Gerp_score,\
+        AlphaMissense as AlphaMissense,\
         aa_change as AA_change,\
         hgvsc as Codon_change,\
         "$callers" as Callers,\

--- a/cre.vcf2db.R
+++ b/cre.vcf2db.R
@@ -451,7 +451,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
                             "Gnomad_af_popmax", "Gnomad_af", "Gnomad_ac", "Gnomad_hom",
                             "Ensembl_transcript_id", "AA_position", "Exon", "Protein_domains", "rsIDs",
                             "Gnomad_oe_lof_score", "Gnomad_oe_mis_score", "Exac_pli_score", "Exac_prec_score", "Exac_pnull_score",
-                            "Conserved_in_30_mammals", "SpliceAI_impact", "SpliceAI_score", "Sift_score", "Polyphen_score", "Cadd_score", "Vest4_score", "Revel_score", "Gerp_score",
+                            "Conserved_in_30_mammals", "SpliceAI_impact", "SpliceAI_score", "Sift_score", "Polyphen_score", "Cadd_score", "Vest4_score", "Revel_score", "Gerp_score","AlphaMissense",
                             "Imprinting_status", "Imprinting_expressed_allele", "Pseudoautosomal", "Gnomad_male_ac",
                             "Number_of_callers", "Old_multiallelic", "UCE_100bp", "UCE_200bp"), noncoding_cols)]
   


### PR DESCRIPTION
- For testing, please checkout crg2 branch "crg2-hg38-alphamissense" branch and cre branch "hg38-alphamissense".
- Tested pipeline on one genome from Mital Lab and Alphamissense annotation column was successfully added to the report (wes.regular) as well as the annotated VCF file.