### PR TITLE
Add ClinVar conflicting statuses

### DIFF
--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -68,7 +68,7 @@ sQuery="select \
         dp as Depth,\
         qual as Quality,\
         gene as Gene,\
-		COALESCE(clinvar_pathogenic, '') || COALESCE( ';' || NULLIF(clinvar_sig,''), '') as Clinvar, \
+		COALESCE(clinvar_pathogenic, '') || COALESCE( ';' || NULLIF(clinvar_sig,''), '') || COALESCE( ';' || NULLIF(clinvar_sig_conf,''), '') as Clinvar, \
         clinvar_status as Clinvar_status, \
         ensembl_gene_id as Ensembl_gene_id,\
         transcript as Ensembl_transcript_id,\


### PR DESCRIPTION
Add details of ClinVar conflicting status using the CLNSIGCONF field in the ClinVar VCF. For example, instead of just annotating a variant as `Conflicting_classifications_of_pathogenicity` it would be annotated as `Conflicting_classifications_of_pathogenicity;Uncertain_significance(2)|Likely_benign(3)`. Associated with [crg2 PR #236](https://github.com/ccmbioinfo/crg2/pull/236).