### PR TITLE
Make matching for variants in ClinVar with gnomad_af_popmax > 1% more permissive

### DIFF
--- a/cre.gemini.variant_impacts.vcf2db.sh
+++ b/cre.gemini.variant_impacts.vcf2db.sh
@@ -119,6 +119,6 @@ else
     gemini query -q "$cQuery" --gt-filter "$s_gt_filter" $file
     # add variants where gnomad freq is > 1%, Clinvar is pathogenic, likely pathogenic or conflicting and any status except no assertion 
     cQuery=$initialQuery
-    cQuery=$cQuery" where v.gnomad_af_popmax > ${max_af} and v.variant_id=i.variant_id and v.clinvar_status != 'no_assertion_criteria_provided' and Clinvar in ('Pathogenic', 'Likely_pathogenic', 'Conflicting_interpretations_of_pathogenicity') "$caller_filter""
+    cQuery=$cQuery" where v.gnomad_af_popmax > ${max_af} and v.variant_id=i.variant_id and v.clinvar_status != 'no_assertion_criteria_provided' and lower(Clinvar) like '%pathogenic%' "$caller_filter""
     gemini query -q "$cQuery" $file
 fi

--- a/cre.gemini2txt.vcf2db.sh
+++ b/cre.gemini2txt.vcf2db.sh
@@ -166,7 +166,7 @@ else
 
     # if allele frequency is > 1% and Clinvar is pathogenic, likely pathogenic or conflicting and any status except for no assertion
     cQuery=$initialQuery
-    cQuery=$cQuery" where gnomad_af_popmax > ${max_af} "$caller_filter" and Clinvar_status != 'no_assertion_criteria_provided' and Clinvar in ('Pathogenic', 'Likely_pathogenic', 'Conflicting_interpretations_of_pathogenicity')"
+    cQuery=$cQuery" where gnomad_af_popmax > ${max_af} "$caller_filter" and Clinvar_status != 'no_assertion_criteria_provided' and lower(Clinvar) like '%pathogenic%'"
     gemini query -q "$cQuery" $file
 
 fi


### PR DESCRIPTION
Variant GRCh38:chr6:g.26092913G>A was excluded from the wes.regular report in an individual because the clinvar_status was 'Pathogenic/Pathogenic,_low_penetrance|other|risk_factor', so it did not match one of 'Pathogenic', 'Likely_pathogenic', or 'Conflicting_interpretations_of_pathogenicity'. I revised the SQL query to include any variant with a clinvar_status (converted to lower case) containing the string 'pathogenic'.